### PR TITLE
Add opencv-engine package

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -89,6 +89,7 @@ end
 python_pip 'remotecv'
 
 python_pip 'graphicsmagick-engine'
+python_pip 'opencv-engine'
 
 # install thumbor
 python_pip 'thumbor' do


### PR DESCRIPTION
Just like graphicsmagick-engine, to use OpenCV with Thumbor, a pip package needs to be installed.
