### PR TITLE
Make pip dependencies configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,7 @@ default['thumbor_ng']['key'] = 'secretkey'
 default['thumbor_ng']['init_style'] = 'upstart' # options: upstart, initd
 default['thumbor_ng']['service_name'] = 'thumbor'
 default['thumbor_ng']['install_method'] = 'pip'
+default['thumbor_ng']['pip_dependencies'] = ['remotecv', 'graphicsmagick-engine', 'opencv-engine']
 default['thumbor_ng']['listen_address'] = '127.0.0.1'
 default['thumbor_ng']['binary'] = '/usr/local/bin/thumbor'
 default['thumbor_ng']['upstart_respawn'] = true

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -86,10 +86,9 @@ required_packages.each do |pkg|
 end
 
 # install dependency pip packages
-python_pip 'remotecv'
-
-python_pip 'graphicsmagick-engine'
-python_pip 'opencv-engine'
+node['thumbor_ng']['pip_dependencies'].each do |pkg|
+  python_pip pkg
+end
 
 # install thumbor
 python_pip 'thumbor' do


### PR DESCRIPTION
This make it possible for developers to install other thumbor-related dependencies (e.g. thumbor_aws)